### PR TITLE
Remove exclude folders since they don't exist

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,8 +29,7 @@ let package = Package(
                 .target(name: "SendBirdUIKit"),
                 .product(name: "SendBirdSDK", package: "SendBirdSDK")
             ],
-            path: "Framework/Dependency",
-            exclude: ["Sample", "Sources"]
+            path: "Framework/Dependency"
         ),
     ]
 )


### PR DESCRIPTION
The current package includes exclude paths that don't exist and causes warnings in Xcode